### PR TITLE
Fixed reference to 3D model

### DIFF
--- a/CP_Axial_L10.0mm_D4.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L10.0mm_D4.5mm_P15.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 16.25 -2.6) (end -1.25 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L10.0mm_D4.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L10.0mm_D4.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L10.0mm_D6.0mm_P15.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L10.0mm_D6.0mm_P15.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 16.25 -3.35) (end -1.25 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L10.0mm_D6.0mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L10.0mm_D6.0mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L11.0mm_D5.0mm_P18.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L11.0mm_D5.0mm_P18.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 19.45 -2.85) (end -1.45 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 18 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L11.0mm_D5.0mm_P18.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L11.0mm_D5.0mm_P18.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L11.0mm_D6.0mm_P18.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L11.0mm_D6.0mm_P18.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 19.45 -3.35) (end -1.45 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 18 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L11.0mm_D6.0mm_P18.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L11.0mm_D6.0mm_P18.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L11.0mm_D8.0mm_P15.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L11.0mm_D8.0mm_P15.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 16.25 -4.35) (end -1.25 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L11.0mm_D8.0mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L11.0mm_D8.0mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L18.0mm_D10.0mm_P25.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L18.0mm_D10.0mm_P25.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 26.45 -5.35) (end -1.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L18.0mm_D10.0mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L18.0mm_D10.0mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L18.0mm_D6.5mm_P25.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L18.0mm_D6.5mm_P25.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 26.45 -3.6) (end -1.45 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L18.0mm_D6.5mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L18.0mm_D6.5mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L18.0mm_D8.0mm_P25.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L18.0mm_D8.0mm_P25.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 26.45 -4.35) (end -1.45 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L18.0mm_D8.0mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L18.0mm_D8.0mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L20.0mm_D10.0mm_P26.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L20.0mm_D10.0mm_P26.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 27.45 -5.35) (end -1.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 26 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L20.0mm_D10.0mm_P26.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L20.0mm_D10.0mm_P26.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L20.0mm_D13.0mm_P26.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L20.0mm_D13.0mm_P26.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 27.45 -6.85) (end -1.45 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 26 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L20.0mm_D13.0mm_P26.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L20.0mm_D13.0mm_P26.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L21.0mm_D8.0mm_P28.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L21.0mm_D8.0mm_P28.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 29.45 -4.35) (end -1.45 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 28 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L21.0mm_D8.0mm_P28.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L21.0mm_D8.0mm_P28.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L25.0mm_D10.0mm_P30.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L25.0mm_D10.0mm_P30.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 31.45 -5.35) (end -1.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 30 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L25.0mm_D10.0mm_P30.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L25.0mm_D10.0mm_P30.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L26.5mm_D20.0mm_P33.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L26.5mm_D20.0mm_P33.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 34.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 33 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L26.5mm_D20.0mm_P33.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L26.5mm_D20.0mm_P33.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L29.0mm_D10.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L29.0mm_D10.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -5.35) (end -1.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L29.0mm_D10.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L29.0mm_D10.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L29.0mm_D13.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L29.0mm_D13.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -6.85) (end -1.45 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L29.0mm_D13.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L29.0mm_D13.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L29.0mm_D16.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L29.0mm_D16.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -8.35) (end -1.45 -8.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L29.0mm_D16.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L29.0mm_D16.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L29.0mm_D20.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L29.0mm_D20.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L29.0mm_D20.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L29.0mm_D20.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L30.0mm_D10.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L30.0mm_D10.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -5.35) (end -1.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L30.0mm_D10.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L30.0mm_D10.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L30.0mm_D12.5mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L30.0mm_D12.5mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -6.6) (end -1.45 -6.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L30.0mm_D12.5mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L30.0mm_D12.5mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L30.0mm_D15.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L30.0mm_D15.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -7.85) (end -1.45 -7.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L30.0mm_D15.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L30.0mm_D15.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L30.0mm_D18.0mm_P35.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L30.0mm_D18.0mm_P35.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 36.45 -9.35) (end -1.45 -9.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 35 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L30.0mm_D18.0mm_P35.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L30.0mm_D18.0mm_P35.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L34.5mm_D20.0mm_P41.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L34.5mm_D20.0mm_P41.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 42.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 41 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L34.5mm_D20.0mm_P41.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L34.5mm_D20.0mm_P41.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L37.0mm_D13.0mm_P43.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L37.0mm_D13.0mm_P43.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 44.45 -6.85) (end -1.45 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 43 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L37.0mm_D13.0mm_P43.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L37.0mm_D13.0mm_P43.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L37.0mm_D16.0mm_P43.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L37.0mm_D16.0mm_P43.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 44.45 -8.35) (end -1.45 -8.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 43 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L37.0mm_D16.0mm_P43.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L37.0mm_D16.0mm_P43.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L37.0mm_D20.0mm_P43.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L37.0mm_D20.0mm_P43.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 44.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 43 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L37.0mm_D20.0mm_P43.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L37.0mm_D20.0mm_P43.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L38.0mm_D18.0mm_P44.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L38.0mm_D18.0mm_P44.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 45.45 -9.35) (end -1.45 -9.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 44 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L38.0mm_D18.0mm_P44.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L38.0mm_D18.0mm_P44.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L38.0mm_D21.0mm_P44.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L38.0mm_D21.0mm_P44.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 45.45 -10.85) (end -1.45 -10.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 44 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L38.0mm_D21.0mm_P44.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L38.0mm_D21.0mm_P44.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L40.0mm_D16.0mm_P48.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L40.0mm_D16.0mm_P48.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 49.45 -8.35) (end -1.45 -8.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 48 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L40.0mm_D16.0mm_P48.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L40.0mm_D16.0mm_P48.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.0mm_D23.0mm_P45.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.0mm_D23.0mm_P45.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 46.45 -11.85) (end -1.45 -11.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 45 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.0mm_D23.0mm_P45.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.0mm_D23.0mm_P45.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.0mm_D26.0mm_P45.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.0mm_D26.0mm_P45.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 46.45 -13.35) (end -1.45 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 45 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.0mm_D26.0mm_P45.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.0mm_D26.0mm_P45.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.0mm_D29.0mm_P45.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.0mm_D29.0mm_P45.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 46.45 -14.85) (end -1.45 -14.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 45 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.0mm_D29.0mm_P45.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.0mm_D29.0mm_P45.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.0mm_D32.0mm_P45.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.0mm_D32.0mm_P45.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 46.45 -16.35) (end -1.45 -16.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 45 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.0mm_D32.0mm_P45.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.0mm_D32.0mm_P45.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.0mm_D35.0mm_P45.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.0mm_D35.0mm_P45.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 46.45 -17.85) (end -1.45 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 45 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.0mm_D35.0mm_P45.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.0mm_D35.0mm_P45.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L42.5mm_D20.0mm_P49.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L42.5mm_D20.0mm_P49.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 50.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 49 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L42.5mm_D20.0mm_P49.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L42.5mm_D20.0mm_P49.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L46.0mm_D20.0mm_P52.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L46.0mm_D20.0mm_P52.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 53.65 -10.35) (end -1.65 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 52 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L46.0mm_D20.0mm_P52.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L46.0mm_D20.0mm_P52.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L55.0mm_D23.0mm_P60.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L55.0mm_D23.0mm_P60.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 61.45 -11.85) (end -1.45 -11.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 60 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L55.0mm_D23.0mm_P60.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L55.0mm_D23.0mm_P60.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L55.0mm_D26.0mm_P60.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L55.0mm_D26.0mm_P60.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 61.45 -13.35) (end -1.45 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 60 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L55.0mm_D26.0mm_P60.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L55.0mm_D26.0mm_P60.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L55.0mm_D29.0mm_P60.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L55.0mm_D29.0mm_P60.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 61.45 -14.85) (end -1.45 -14.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 60 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L55.0mm_D29.0mm_P60.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L55.0mm_D29.0mm_P60.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L55.0mm_D32.0mm_P60.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L55.0mm_D32.0mm_P60.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 61.45 -16.35) (end -1.45 -16.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 60 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L55.0mm_D32.0mm_P60.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L55.0mm_D32.0mm_P60.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L55.0mm_D35.0mm_P60.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L55.0mm_D35.0mm_P60.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 61.45 -17.85) (end -1.45 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 60 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L55.0mm_D35.0mm_P60.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L55.0mm_D35.0mm_P60.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L67.0mm_D23.0mm_P75.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L67.0mm_D23.0mm_P75.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 76.45 -11.85) (end -1.45 -11.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L67.0mm_D23.0mm_P75.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L67.0mm_D23.0mm_P75.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L67.0mm_D26.0mm_P75.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L67.0mm_D26.0mm_P75.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 76.45 -13.35) (end -1.45 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L67.0mm_D26.0mm_P75.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L67.0mm_D26.0mm_P75.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L67.0mm_D29.0mm_P75.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L67.0mm_D29.0mm_P75.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 76.45 -14.85) (end -1.45 -14.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L67.0mm_D29.0mm_P75.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L67.0mm_D29.0mm_P75.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L67.0mm_D32.0mm_P75.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L67.0mm_D32.0mm_P75.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 76.45 -16.35) (end -1.45 -16.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L67.0mm_D32.0mm_P75.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L67.0mm_D32.0mm_P75.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L67.0mm_D35.0mm_P75.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L67.0mm_D35.0mm_P75.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 76.45 -17.85) (end -1.45 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L67.0mm_D35.0mm_P75.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L67.0mm_D35.0mm_P75.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L80.0mm_D23.0mm_P85.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L80.0mm_D23.0mm_P85.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 86.45 -11.85) (end -1.45 -11.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 85 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L80.0mm_D23.0mm_P85.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L80.0mm_D23.0mm_P85.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L80.0mm_D26.0mm_P85.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L80.0mm_D26.0mm_P85.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 86.45 -13.35) (end -1.45 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 85 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L80.0mm_D26.0mm_P85.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L80.0mm_D26.0mm_P85.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L80.0mm_D29.0mm_P85.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L80.0mm_D29.0mm_P85.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 86.45 -14.85) (end -1.45 -14.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 85 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L80.0mm_D29.0mm_P85.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L80.0mm_D29.0mm_P85.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L80.0mm_D32.0mm_P85.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L80.0mm_D32.0mm_P85.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 86.45 -16.35) (end -1.45 -16.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 85 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L80.0mm_D32.0mm_P85.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L80.0mm_D32.0mm_P85.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L80.0mm_D35.0mm_P85.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L80.0mm_D35.0mm_P85.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 86.45 -17.85) (end -1.45 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 85 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L80.0mm_D35.0mm_P85.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L80.0mm_D35.0mm_P85.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L93.0mm_D23.0mm_P100.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L93.0mm_D23.0mm_P100.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 101.45 -11.85) (end -1.45 -11.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 100 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L93.0mm_D23.0mm_P100.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L93.0mm_D23.0mm_P100.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L93.0mm_D26.0mm_P100.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L93.0mm_D26.0mm_P100.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 101.45 -13.35) (end -1.45 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 100 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L93.0mm_D26.0mm_P100.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L93.0mm_D26.0mm_P100.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L93.0mm_D29.0mm_P100.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L93.0mm_D29.0mm_P100.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 101.45 -14.85) (end -1.45 -14.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 100 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L93.0mm_D29.0mm_P100.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L93.0mm_D29.0mm_P100.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L93.0mm_D32.0mm_P100.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L93.0mm_D32.0mm_P100.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 101.45 -16.35) (end -1.45 -16.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 100 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L93.0mm_D32.0mm_P100.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L93.0mm_D32.0mm_P100.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Axial_L93.0mm_D35.0mm_P100.00mm_Horizontal.kicad_mod
+++ b/CP_Axial_L93.0mm_D35.0mm_P100.00mm_Horizontal.kicad_mod
@@ -41,7 +41,7 @@
   (fp_line (start 101.45 -17.85) (end -1.45 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 100 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Axial_L93.0mm_D35.0mm_P100.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/CP_Axial_L93.0mm_D35.0mm_P100.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P2.50mm.kicad_mod
@@ -196,7 +196,7 @@
   (fp_line (start 6.6 -5.35) (end -4.1 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P2.50mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P2.50mm_P5.00mm.kicad_mod
@@ -215,7 +215,7 @@
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at -0.670937 -1.6) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 3.170937 1.6) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P2.50mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P2.50mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P3.50mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P3.50mm.kicad_mod
@@ -206,7 +206,7 @@
   (fp_line (start 7.1 -5.35) (end -3.6 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 3.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P3.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P3.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P3.80mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P3.80mm.kicad_mod
@@ -206,7 +206,7 @@
   (fp_line (start 7.25 -5.35) (end -3.45 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 3.8 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P3.80mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P3.80mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P5.00mm.kicad_mod
@@ -208,7 +208,7 @@
   (fp_line (start 7.85 -5.35) (end -2.85 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P5.00mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P5.00mm_P7.50mm.kicad_mod
@@ -217,7 +217,7 @@
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at -0.672144 -2) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5.672144 2) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P5.00mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P5.00mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D10.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D10.0mm_P7.50mm.kicad_mod
@@ -208,7 +208,7 @@
   (fp_line (start 9.1 -5.35) (end -1.6 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D10.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D10.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D12.5mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D12.5mm_P2.50mm.kicad_mod
@@ -244,7 +244,7 @@
   (fp_line (start 7.85 -6.6) (end -5.35 -6.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D12.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D12.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D12.5mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D12.5mm_P5.00mm.kicad_mod
@@ -247,7 +247,7 @@
   (fp_line (start 9.1 -6.6) (end -4.1 -6.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D12.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D12.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D12.5mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D12.5mm_P7.50mm.kicad_mod
@@ -249,7 +249,7 @@
   (fp_line (start 10.35 -6.6) (end -2.85 -6.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D12.5mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D12.5mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D13.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D13.0mm_P2.50mm.kicad_mod
@@ -250,7 +250,7 @@
   (fp_line (start 8.1 -6.85) (end -5.6 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D13.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D13.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D13.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D13.0mm_P5.00mm.kicad_mod
@@ -253,7 +253,7 @@
   (fp_line (start 9.35 -6.85) (end -4.35 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D13.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D13.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D13.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D13.0mm_P7.50mm.kicad_mod
@@ -255,7 +255,7 @@
   (fp_line (start 10.6 -6.85) (end -3.1 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D13.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D13.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D14.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D14.0mm_P5.00mm.kicad_mod
@@ -266,7 +266,7 @@
   (fp_line (start 9.85 -7.35) (end -4.85 -7.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D14.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D14.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D14.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D14.0mm_P7.50mm.kicad_mod
@@ -266,7 +266,7 @@
   (fp_line (start 11.1 -7.35) (end -3.6 -7.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D14.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D14.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D16.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D16.0mm_P7.50mm.kicad_mod
@@ -291,7 +291,7 @@
   (fp_line (start 12.1 -8.35) (end -4.6 -8.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D16.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D16.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D17.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D17.0mm_P7.50mm.kicad_mod
@@ -303,7 +303,7 @@
   (fp_line (start 12.6 -8.85) (end -5.1 -8.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D17.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D17.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D18.0mm_P7.50mm.kicad_mod
+++ b/CP_Radial_D18.0mm_P7.50mm.kicad_mod
@@ -316,7 +316,7 @@
   (fp_line (start 13.1 -9.35) (end -5.6 -9.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D18.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D18.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -478,7 +478,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D22.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D22.0mm_P10.00mm_SnapIn.kicad_mod
@@ -406,7 +406,7 @@
   (fp_line (start 16.35 -11.35) (end -6.35 -11.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D22.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D22.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D24.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D24.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -503,7 +503,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D24.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D24.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D24.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D24.0mm_P10.00mm_SnapIn.kicad_mod
@@ -431,7 +431,7 @@
   (fp_line (start 17.35 -12.35) (end -7.35 -12.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D24.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D24.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D25.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D25.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -515,7 +515,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D25.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D25.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D25.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D25.0mm_P10.00mm_SnapIn.kicad_mod
@@ -443,7 +443,7 @@
   (fp_line (start 17.85 -12.85) (end -7.85 -12.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D25.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D25.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D26.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D26.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -528,7 +528,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D26.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D26.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D26.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D26.0mm_P10.00mm_SnapIn.kicad_mod
@@ -456,7 +456,7 @@
   (fp_line (start 18.35 -13.35) (end -8.35 -13.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D26.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D26.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D30.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D30.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -578,7 +578,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D30.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D30.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D30.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D30.0mm_P10.00mm_SnapIn.kicad_mod
@@ -506,7 +506,7 @@
   (fp_line (start 20.35 -15.35) (end -10.35 -15.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D30.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D30.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D35.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D35.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -640,7 +640,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D35.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D35.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D35.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D35.0mm_P10.00mm_SnapIn.kicad_mod
@@ -568,7 +568,7 @@
   (fp_line (start 22.85 -17.85) (end -12.85 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D35.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D35.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D4.0mm_P1.50mm.kicad_mod
+++ b/CP_Radial_D4.0mm_P1.50mm.kicad_mod
@@ -113,7 +113,7 @@
   (fp_line (start 3.1 -2.35) (end -1.6 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.2 1.2) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 1.5 0) (size 1.2 1.2) (drill 0.6) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D4.0mm_P1.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D4.0mm_P1.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D4.0mm_P2.00mm.kicad_mod
+++ b/CP_Radial_D4.0mm_P2.00mm.kicad_mod
@@ -113,7 +113,7 @@
   (fp_line (start 3.35 -2.35) (end -1.35 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.2 1.2) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2 0) (size 1.2 1.2) (drill 0.6) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D4.0mm_P2.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D4.0mm_P2.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D40.0mm_P10.00mm_3pin_SnapIn.kicad_mod
+++ b/CP_Radial_D40.0mm_P10.00mm_3pin_SnapIn.kicad_mod
@@ -703,7 +703,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 6.7 -4.75) (size 5 5) (drill 2.5) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D40.0mm_P10.00mm_3pin_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D40.0mm_P10.00mm_3pin_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D40.0mm_P10.00mm_SnapIn.kicad_mod
+++ b/CP_Radial_D40.0mm_P10.00mm_SnapIn.kicad_mod
@@ -631,7 +631,7 @@
   (fp_line (start 25.35 -20.35) (end -15.35 -20.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 4 4) (drill 2.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D40.0mm_P10.00mm_SnapIn.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D40.0mm_P10.00mm_SnapIn.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D5.0mm_P2.00mm.kicad_mod
+++ b/CP_Radial_D5.0mm_P2.00mm.kicad_mod
@@ -135,7 +135,7 @@
   (fp_line (start 3.85 -2.85) (end -1.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D5.0mm_P2.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D5.0mm_P2.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D5.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D5.0mm_P2.50mm.kicad_mod
@@ -135,7 +135,7 @@
   (fp_line (start 4.1 -2.85) (end -1.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D5.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D5.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D6.3mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D6.3mm_P2.50mm.kicad_mod
@@ -151,7 +151,7 @@
   (fp_line (start 4.75 -3.5) (end -2.25 -3.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D6.3mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D6.3mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D7.5mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D7.5mm_P2.50mm.kicad_mod
@@ -164,7 +164,7 @@
   (fp_line (start 5.35 -4.1) (end -2.85 -4.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D7.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D7.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D8.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_D8.0mm_P2.50mm.kicad_mod
@@ -171,7 +171,7 @@
   (fp_line (start 5.6 -4.35) (end -3.1 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D8.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D8.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D8.0mm_P3.50mm.kicad_mod
+++ b/CP_Radial_D8.0mm_P3.50mm.kicad_mod
@@ -171,7 +171,7 @@
   (fp_line (start 6.1 -4.35) (end -2.6 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 3.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D8.0mm_P3.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D8.0mm_P3.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D8.0mm_P3.80mm.kicad_mod
+++ b/CP_Radial_D8.0mm_P3.80mm.kicad_mod
@@ -171,7 +171,7 @@
   (fp_line (start 6.25 -4.35) (end -2.45 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 3.8 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D8.0mm_P3.80mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D8.0mm_P3.80mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_D8.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_D8.0mm_P5.00mm.kicad_mod
@@ -173,7 +173,7 @@
   (fp_line (start 6.85 -4.35) (end -1.85 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_D8.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_D8.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D10.5mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D10.5mm_P2.50mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 6.85 -5.6) (end -4.35 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D10.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D10.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D10.5mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D10.5mm_P5.00mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 8.1 -5.6) (end -3.1 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D10.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D10.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D4.5mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D4.5mm_P2.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.85 -2.6) (end -1.35 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D4.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D4.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D4.5mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D4.5mm_P5.00mm.kicad_mod
@@ -20,7 +20,7 @@
   (fp_line (start 6.05 -2.6) (end -1.05 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D4.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D4.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D5.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D5.0mm_P2.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 4.1 -2.85) (end -1.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D5.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D5.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D5.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D5.0mm_P5.00mm.kicad_mod
@@ -20,7 +20,7 @@
   (fp_line (start 6.05 -2.85) (end -1.05 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D5.5mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D5.5mm_P2.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 4.35 -3.1) (end -1.85 -3.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D5.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D5.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D5.5mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D5.5mm_P5.00mm.kicad_mod
@@ -20,7 +20,7 @@
   (fp_line (start 6.05 -3.1) (end -1.05 -3.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D5.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D5.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D6.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D6.0mm_P2.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 4.6 -3.35) (end -2.1 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D6.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D6.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D6.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D6.0mm_P5.00mm.kicad_mod
@@ -20,7 +20,7 @@
   (fp_line (start 6.05 -3.35) (end -1.05 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D6.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D6.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D7.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D7.0mm_P2.50mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 5.1 -3.85) (end -2.6 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D7.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D7.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D7.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D7.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -3.85) (end -1.35 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D7.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D7.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D8.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D8.0mm_P2.50mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 5.6 -4.35) (end -3.1 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D8.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D8.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D8.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D8.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.85 -4.35) (end -1.85 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D8.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D8.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D9.0mm_P2.50mm.kicad_mod
+++ b/CP_Radial_Tantal_D9.0mm_P2.50mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 6.1 -4.85) (end -3.6 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D9.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D9.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/CP_Radial_Tantal_D9.0mm_P5.00mm.kicad_mod
+++ b/CP_Radial_Tantal_D9.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 7.35 -4.85) (end -2.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/CP_Radial_Tantal_D9.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/CP_Radial_Tantal_D9.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D10.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D10.5mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -5.6) (end -1.05 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D10.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D10.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D10.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D10.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -5.6) (end -1.05 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D10.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D10.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D6.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D6.5mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -3.6) (end -1.05 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D6.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D6.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D6.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D6.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -3.6) (end -1.05 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D6.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D6.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D7.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D7.5mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -4.1) (end -1.05 -4.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D7.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D7.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D7.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D7.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -4.1) (end -1.05 -4.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D7.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D7.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D8.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D8.5mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -4.6) (end -1.05 -4.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D8.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D8.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D8.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D8.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -4.6) (end -1.05 -4.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D8.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D8.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D9.5mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D9.5mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -5.1) (end -1.05 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D9.5mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D9.5mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L12.0mm_D9.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L12.0mm_D9.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -5.1) (end -1.05 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L12.0mm_D9.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L12.0mm_D9.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L17.0mm_D6.5mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L17.0mm_D6.5mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -3.6) (end -1.05 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L17.0mm_D6.5mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L17.0mm_D6.5mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L17.0mm_D6.5mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L17.0mm_D6.5mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -3.6) (end -1.05 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L17.0mm_D6.5mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L17.0mm_D6.5mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L17.0mm_D7.0mm_P20.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L17.0mm_D7.0mm_P20.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 21.05 -3.85) (end -1.05 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 20 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L17.0mm_D7.0mm_P20.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L17.0mm_D7.0mm_P20.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L17.0mm_D7.0mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L17.0mm_D7.0mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -3.85) (end -1.05 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L17.0mm_D7.0mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L17.0mm_D7.0mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L19.0mm_D7.5mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L19.0mm_D7.5mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -4.1) (end -1.05 -4.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L19.0mm_D7.5mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L19.0mm_D7.5mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L19.0mm_D8.0mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L19.0mm_D8.0mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -4.35) (end -1.05 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L19.0mm_D8.0mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L19.0mm_D8.0mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L19.0mm_D9.0mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L19.0mm_D9.0mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -4.85) (end -1.05 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L19.0mm_D9.0mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L19.0mm_D9.0mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L19.0mm_D9.5mm_P25.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L19.0mm_D9.5mm_P25.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 26.05 -5.1) (end -1.05 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L19.0mm_D9.5mm_P25.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L19.0mm_D9.5mm_P25.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L22.0mm_D10.5mm_P27.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L22.0mm_D10.5mm_P27.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 28.55 -5.6) (end -1.05 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 27.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L22.0mm_D10.5mm_P27.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L22.0mm_D10.5mm_P27.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L22.0mm_D9.5mm_P27.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L22.0mm_D9.5mm_P27.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 28.55 -5.1) (end -1.05 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 27.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L22.0mm_D9.5mm_P27.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L22.0mm_D9.5mm_P27.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L3.8mm_D2.6mm_P10.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L3.8mm_D2.6mm_P10.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 11.05 -1.65) (end -1.05 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L3.8mm_D2.6mm_P10.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L3.8mm_D2.6mm_P10.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L3.8mm_D2.6mm_P12.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L3.8mm_D2.6mm_P12.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 13.55 -1.65) (end -1.05 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 12.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L3.8mm_D2.6mm_P12.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L3.8mm_D2.6mm_P12.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L3.8mm_D2.6mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L3.8mm_D2.6mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -1.65) (end -1.05 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L3.8mm_D2.6mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L3.8mm_D2.6mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L3.8mm_D2.6mm_P7.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L3.8mm_D2.6mm_P7.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 8.55 -1.65) (end -1.05 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L3.8mm_D2.6mm_P7.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L3.8mm_D2.6mm_P7.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L5.1mm_D3.1mm_P10.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L5.1mm_D3.1mm_P10.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 11.05 -1.9) (end -1.05 -1.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L5.1mm_D3.1mm_P10.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L5.1mm_D3.1mm_P10.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L5.1mm_D3.1mm_P12.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L5.1mm_D3.1mm_P12.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 13.55 -1.9) (end -1.05 -1.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 12.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L5.1mm_D3.1mm_P12.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L5.1mm_D3.1mm_P12.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L5.1mm_D3.1mm_P15.00mm_Horizontal.kicad_mod
+++ b/C_Axial_L5.1mm_D3.1mm_P15.00mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 16.05 -1.9) (end -1.05 -1.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 15 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L5.1mm_D3.1mm_P15.00mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L5.1mm_D3.1mm_P15.00mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Axial_L5.1mm_D3.1mm_P7.50mm_Horizontal.kicad_mod
+++ b/C_Axial_L5.1mm_D3.1mm_P7.50mm_Horizontal.kicad_mod
@@ -25,7 +25,7 @@
   (fp_line (start 8.55 -1.9) (end -1.05 -1.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Axial_L5.1mm_D3.1mm_P7.50mm_Horizontal.wrl
+  (model Capacitors_THT.3dshapes/C_Axial_L5.1mm_D3.1mm_P7.50mm_Horizontal.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D10.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D10.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 7.85 -1.6) (end -2.85 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D10.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D10.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D10.5mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D10.5mm_W5.0mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.25 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D10.5mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D10.5mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D10.5mm_W5.0mm_P5.00mm.kicad_mod
+++ b/C_Disc_D10.5mm_W5.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 8.1 -2.85) (end -3.1 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D10.5mm_W5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D10.5mm_W5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D10.5mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D10.5mm_W5.0mm_P7.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.35 -2.85) (end -1.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D10.5mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D10.5mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D11.0mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D11.0mm_W5.0mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.25 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D11.0mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D11.0mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D11.0mm_W5.0mm_P5.00mm.kicad_mod
+++ b/C_Disc_D11.0mm_W5.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 8.35 -2.85) (end -3.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D11.0mm_W5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D11.0mm_W5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D11.0mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D11.0mm_W5.0mm_P7.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.6 -2.85) (end -2.1 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D11.0mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D11.0mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D12.0mm_W4.4mm_P7.75mm.kicad_mod
+++ b/C_Disc_D12.0mm_W4.4mm_P7.75mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 10.2 -2.55) (end -2.45 -2.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.75 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D12.0mm_W4.4mm_P7.75mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D12.0mm_W4.4mm_P7.75mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D12.5mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D12.5mm_W5.0mm_P10.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.6 -2.85) (end -1.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D12.5mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D12.5mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D12.5mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D12.5mm_W5.0mm_P7.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 10.35 -2.85) (end -2.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D12.5mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D12.5mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D14.5mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D14.5mm_W5.0mm_P10.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 12.6 -2.85) (end -2.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D14.5mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D14.5mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D14.5mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D14.5mm_W5.0mm_P7.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.35 -2.85) (end -3.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D14.5mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D14.5mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D16.0mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D16.0mm_W5.0mm_P10.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 13.35 -2.85) (end -3.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D16.0mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D16.0mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D16.0mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D16.0mm_W5.0mm_P7.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 12.1 -2.85) (end -4.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D16.0mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D16.0mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D3.0mm_W1.6mm_P2.50mm.kicad_mod
+++ b/C_Disc_D3.0mm_W1.6mm_P2.50mm.kicad_mod
@@ -19,7 +19,7 @@
   (fp_line (start 3.55 -1.15) (end -1.05 -1.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D3.0mm_W1.6mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D3.0mm_W1.6mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D3.0mm_W2.0mm_P2.50mm.kicad_mod
+++ b/C_Disc_D3.0mm_W2.0mm_P2.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 3.55 -1.35) (end -1.05 -1.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D3.0mm_W2.0mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D3.0mm_W2.0mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D3.4mm_W2.1mm_P2.50mm.kicad_mod
+++ b/C_Disc_D3.4mm_W2.1mm_P2.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 3.55 -1.4) (end -1.05 -1.4) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D3.4mm_W2.1mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D3.4mm_W2.1mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D3.8mm_W2.6mm_P2.50mm.kicad_mod
+++ b/C_Disc_D3.8mm_W2.6mm_P2.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 3.55 -1.65) (end -1.05 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D3.8mm_W2.6mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D3.8mm_W2.6mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D4.3mm_W1.9mm_P5.00mm.kicad_mod
+++ b/C_Disc_D4.3mm_W1.9mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -1.3) (end -1.05 -1.3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D4.3mm_W1.9mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D4.3mm_W1.9mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D4.7mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D4.7mm_W2.5mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -1.6) (end -1.05 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D4.7mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D4.7mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D5.0mm_W2.5mm_P2.50mm.kicad_mod
+++ b/C_Disc_D5.0mm_W2.5mm_P2.50mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 4.1 -1.6) (end -1.6 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D5.0mm_W2.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D5.0mm_W2.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D5.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D5.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -1.6) (end -1.05 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D5.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D5.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D5.1mm_W3.2mm_P5.00mm.kicad_mod
+++ b/C_Disc_D5.1mm_W3.2mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -1.95) (end -1.05 -1.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D5.1mm_W3.2mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D5.1mm_W3.2mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D6.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D6.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -1.6) (end -1.05 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D6.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D6.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D6.0mm_W4.4mm_P5.00mm.kicad_mod
+++ b/C_Disc_D6.0mm_W4.4mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.05 -2.55) (end -1.05 -2.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D6.0mm_W4.4mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D6.0mm_W4.4mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D7.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -1.6) (end -1.35 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.5mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D7.5mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.6 -1.6) (end -1.6 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.5mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.5mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.5mm_W4.4mm_P5.00mm.kicad_mod
+++ b/C_Disc_D7.5mm_W4.4mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.6 -2.55) (end -1.6 -2.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.5mm_W4.4mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.5mm_W4.4mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.5mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D7.5mm_W5.0mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.25 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.5mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.5mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.5mm_W5.0mm_P5.00mm.kicad_mod
+++ b/C_Disc_D7.5mm_W5.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.6 -2.85) (end -1.6 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.5mm_W5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.5mm_W5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D7.5mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D7.5mm_W5.0mm_P7.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.75 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D7.5mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D7.5mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D8.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D8.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.85 -1.6) (end -1.85 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D8.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D8.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D8.0mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D8.0mm_W5.0mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.25 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D8.0mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D8.0mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D8.0mm_W5.0mm_P5.00mm.kicad_mod
+++ b/C_Disc_D8.0mm_W5.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.85 -2.85) (end -1.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D8.0mm_W5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D8.0mm_W5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D8.0mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D8.0mm_W5.0mm_P7.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.75 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D8.0mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D8.0mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D9.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Disc_D9.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 7.35 -1.6) (end -2.35 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D9.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D9.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D9.0mm_W5.0mm_P10.00mm.kicad_mod
+++ b/C_Disc_D9.0mm_W5.0mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.25 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D9.0mm_W5.0mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D9.0mm_W5.0mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D9.0mm_W5.0mm_P5.00mm.kicad_mod
+++ b/C_Disc_D9.0mm_W5.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 7.35 -2.85) (end -2.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D9.0mm_W5.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D9.0mm_W5.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Disc_D9.0mm_W5.0mm_P7.50mm.kicad_mod
+++ b/C_Disc_D9.0mm_W5.0mm_P7.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.75 -2.85) (end -1.25 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Disc_D9.0mm_W5.0mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Disc_D9.0mm_W5.0mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W2.5mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.0mm_W2.5mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.1 -1.6) (end -1.6 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W2.5mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W2.5mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W3.0mm_P7.50mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L10.0mm_W3.0mm_P7.50mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.1 -1.85) (end -1.6 -1.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W3.0mm_P7.50mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W3.0mm_P7.50mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W3.0mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.0mm_W3.0mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.1 -1.85) (end -1.6 -1.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W3.0mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W3.0mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W4.0mm_P7.50mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L10.0mm_W4.0mm_P7.50mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.1 -2.35) (end -1.6 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W4.0mm_P7.50mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W4.0mm_P7.50mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W4.0mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.0mm_W4.0mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.1 -2.35) (end -1.6 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W4.0mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W4.0mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.0mm_W5.0mm_P5.00mm_P7.50mm.kicad_mod
+++ b/C_Rect_L10.0mm_W5.0mm_P5.00mm_P7.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (pad 2 thru_hole circle (at 6.25 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.0mm_W5.0mm_P5.00mm_P7.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.0mm_W5.0mm_P5.00mm_P7.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.3mm_W4.5mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.3mm_W4.5mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.25 -2.6) (end -1.75 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.3mm_W4.5mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.3mm_W4.5mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.3mm_W5.0mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.3mm_W5.0mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.25 -2.85) (end -1.75 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.3mm_W5.0mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.3mm_W5.0mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.3mm_W5.7mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.3mm_W5.7mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.25 -3.2) (end -1.75 -3.2) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.3mm_W5.7mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.3mm_W5.7mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L10.3mm_W7.2mm_P7.50mm_MKS4.kicad_mod
+++ b/C_Rect_L10.3mm_W7.2mm_P7.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 9.25 -3.95) (end -1.75 -3.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L10.3mm_W7.2mm_P7.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L10.3mm_W7.2mm_P7.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W2.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W2.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -1.75) (end -1.05 -1.75) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W2.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W2.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W3.4mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W3.4mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -2.05) (end -1.05 -2.05) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W3.4mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W3.4mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W3.5mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W3.5mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -2.1) (end -1.05 -2.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W3.5mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W3.5mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W4.2mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W4.2mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -2.45) (end -1.05 -2.45) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W4.2mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W4.2mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W4.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W4.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -2.5) (end -1.05 -2.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W4.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W4.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W5.1mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W5.1mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -2.9) (end -1.05 -2.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W5.1mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W5.1mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W5.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W5.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -3) (end -1.05 -3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W5.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W5.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W6.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W6.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -3.5) (end -1.05 -3.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W6.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W6.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W6.4mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W6.4mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -3.55) (end -1.05 -3.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W6.4mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W6.4mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W7.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W7.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -4) (end -1.05 -4) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W7.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W7.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.0mm_W8.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.0mm_W8.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.05 -4.75) (end -1.05 -4.75) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.0mm_W8.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.0mm_W8.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W2.0mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W2.0mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -1.35) (end -1.1 -1.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W2.0mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W2.0mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W2.6mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W2.6mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -1.65) (end -1.1 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W2.6mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W2.6mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W2.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W2.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -1.75) (end -1.1 -1.75) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W2.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W2.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W3.2mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W3.2mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -1.95) (end -1.1 -1.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W3.2mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W3.2mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W3.5mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W3.5mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.1) (end -1.1 -2.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W3.5mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W3.5mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W3.6mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W3.6mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.15) (end -1.1 -2.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W3.6mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W3.6mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W4.0mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W4.0mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.35) (end -1.1 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W4.0mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W4.0mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W4.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W4.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.5) (end -1.1 -2.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W4.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W4.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W4.5mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W4.5mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.6) (end -1.1 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W4.5mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W4.5mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W5.0mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W5.0mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.85) (end -1.1 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W5.0mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W5.0mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W5.1mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W5.1mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.9) (end -1.1 -2.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W5.1mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W5.1mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W5.2mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W5.2mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -2.95) (end -1.1 -2.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W5.2mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W5.2mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W5.6mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W5.6mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -3.15) (end -1.1 -3.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W5.6mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W5.6mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W6.4mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W6.4mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -3.55) (end -1.1 -3.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W6.4mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W6.4mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W6.6mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W6.6mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -3.65) (end -1.1 -3.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W6.6mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W6.6mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W6.9mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W6.9mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -3.8) (end -1.1 -3.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W6.9mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W6.9mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W7.3mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W7.3mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -4) (end -1.1 -4) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W7.3mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W7.3mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W7.5mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W7.5mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -4.1) (end -1.1 -4.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W7.5mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W7.5mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W7.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W7.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -4.25) (end -1.1 -4.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W7.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W7.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W8.0mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W8.0mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -4.35) (end -1.1 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W8.0mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W8.0mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W8.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W8.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -4.75) (end -1.1 -4.75) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W8.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W8.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W9.5mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W9.5mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -5.1) (end -1.1 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W9.5mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W9.5mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L11.5mm_W9.8mm_P10.00mm_MKT.kicad_mod
+++ b/C_Rect_L11.5mm_W9.8mm_P10.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 11.1 -5.25) (end -1.1 -5.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L11.5mm_W9.8mm_P10.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L11.5mm_W9.8mm_P10.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W3.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.0mm_W3.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.85 -1.85) (end -1.85 -1.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W3.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W3.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.0mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.85 -2.35) (end -1.85 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.0mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.85 -2.85) (end -1.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W6.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.0mm_W6.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.85 -3.35) (end -1.85 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W6.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W6.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W6.5mm_P7.50mm_P10.00mm.kicad_mod
+++ b/C_Rect_L13.0mm_W6.5mm_P7.50mm_P10.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (pad 2 thru_hole circle (at 8.75 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W6.5mm_P7.50mm_P10.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W6.5mm_P7.50mm_P10.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.0mm_W8.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.0mm_W8.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 11.85 -4.35) (end -1.85 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.0mm_W8.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.0mm_W8.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.5mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.5mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 12.1 -2.35) (end -2.1 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.5mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.5mm_W4.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L13.5mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
+++ b/C_Rect_L13.5mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 12.1 -2.85) (end -2.1 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 0) (size 2 2) (drill 1.0) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L13.5mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L13.5mm_W5.0mm_P10.00mm_FKS3_FKP3_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W10.7mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W10.7mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -5.7) (end -1.35 -5.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W10.7mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W10.7mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W10.9mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W10.9mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -5.8) (end -1.35 -5.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W10.9mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W10.9mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W11.2mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W11.2mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -5.95) (end -1.35 -5.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W11.2mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W11.2mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W11.8mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W11.8mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -6.25) (end -1.35 -6.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W11.8mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W11.8mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W13.5mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W13.5mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -7.1) (end -1.35 -7.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W13.5mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W13.5mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W13.7mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W13.7mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -7.2) (end -1.35 -7.2) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W13.7mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W13.7mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W13.9mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W13.9mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -7.3) (end -1.35 -7.3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W13.9mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W13.9mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W4.7mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W4.7mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -2.7) (end -1.35 -2.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W4.7mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W4.7mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W4.9mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W4.9mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -2.8) (end -1.35 -2.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W4.9mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W4.9mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W5.0mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W5.0mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -2.85) (end -1.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W5.0mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W5.0mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W6.0mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W6.0mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -3.35) (end -1.35 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W6.0mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W6.0mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W7.0mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W7.0mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -3.85) (end -1.35 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W7.0mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W7.0mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W7.3mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W7.3mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -4) (end -1.35 -4) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W7.3mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W7.3mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W8.7mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W8.7mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -4.7) (end -1.35 -4.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W8.7mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W8.7mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W8.9mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W8.9mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -4.8) (end -1.35 -4.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W8.9mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W8.9mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W9.0mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W9.0mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -4.85) (end -1.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W9.0mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W9.0mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L16.5mm_W9.2mm_P15.00mm_MKT.kicad_mod
+++ b/C_Rect_L16.5mm_W9.2mm_P15.00mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 16.35 -4.95) (end -1.35 -4.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L16.5mm_W9.2mm_P15.00mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L16.5mm_W9.2mm_P15.00mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W11.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W11.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -5.85) (end -1.85 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W11.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W11.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W5.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W5.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -2.85) (end -1.85 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W5.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W5.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W6.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W6.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -3.35) (end -1.85 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W6.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W6.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W7.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W7.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -3.85) (end -1.85 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W7.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W7.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W8.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W8.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -4.35) (end -1.85 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W8.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W8.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L18.0mm_W9.0mm_P15.00mm_FKS3_FKP3.kicad_mod
+++ b/C_Rect_L18.0mm_W9.0mm_P15.00mm_FKS3_FKP3.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 16.85 -4.85) (end -1.85 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L18.0mm_W9.0mm_P15.00mm_FKS3_FKP3.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L18.0mm_W9.0mm_P15.00mm_FKS3_FKP3.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W11.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W11.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -5.85) (end -2.35 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W11.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W11.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W5.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W5.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -2.85) (end -2.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W5.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W5.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W6.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W6.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -3.35) (end -2.35 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W6.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W6.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W7.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W7.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -3.85) (end -2.35 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W7.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W7.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W8.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W8.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -4.35) (end -2.35 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W8.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W8.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L19.0mm_W9.0mm_P15.00mm_MKS4.kicad_mod
+++ b/C_Rect_L19.0mm_W9.0mm_P15.00mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 17.35 -4.85) (end -2.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 15 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L19.0mm_W9.0mm_P15.00mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L19.0mm_W9.0mm_P15.00mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W10.1mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W10.1mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -5.4) (end -1.45 -5.4) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W10.1mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W10.1mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W10.3mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W10.3mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -5.5) (end -1.45 -5.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W10.3mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W10.3mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W10.9mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W10.9mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -5.8) (end -1.45 -5.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W10.9mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W10.9mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W12.2mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W12.2mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -6.45) (end -1.45 -6.45) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W12.2mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W12.2mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W12.6mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W12.6mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -6.65) (end -1.45 -6.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W12.6mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W12.6mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W12.8mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W12.8mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -6.75) (end -1.45 -6.75) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W12.8mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W12.8mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W7.0mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W7.0mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -3.85) (end -1.45 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W7.0mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W7.0mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W8.3mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W8.3mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -4.5) (end -1.45 -4.5) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W8.3mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W8.3mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L24.0mm_W8.6mm_P22.50mm_MKT.kicad_mod
+++ b/C_Rect_L24.0mm_W8.6mm_P22.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 23.95 -4.65) (end -1.45 -4.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L24.0mm_W8.6mm_P22.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L24.0mm_W8.6mm_P22.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W10.5mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W10.5mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -5.6) (end -2.35 -5.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W10.5mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W10.5mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W11.5mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W11.5mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -6.1) (end -2.35 -6.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W11.5mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W11.5mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W5.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W5.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -2.85) (end -2.35 -2.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W5.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W5.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W6.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W6.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -3.35) (end -2.35 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W6.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W6.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W7.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W7.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -3.85) (end -2.35 -3.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W7.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W7.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L26.5mm_W8.5mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L26.5mm_W8.5mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -4.6) (end -2.35 -4.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L26.5mm_W8.5mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L26.5mm_W8.5mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L27.0mm_W11.0mm_P22.00mm.kicad_mod
+++ b/C_Rect_L27.0mm_W11.0mm_P22.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -5.85) (end -2.85 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L27.0mm_W11.0mm_P22.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L27.0mm_W11.0mm_P22.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L27.0mm_W9.0mm_P22.00mm.kicad_mod
+++ b/C_Rect_L27.0mm_W9.0mm_P22.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 24.85 -4.85) (end -2.85 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L27.0mm_W9.0mm_P22.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L27.0mm_W9.0mm_P22.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L27.0mm_W9.0mm_P23.00mm.kicad_mod
+++ b/C_Rect_L27.0mm_W9.0mm_P23.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 25.35 -4.85) (end -2.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 23 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L27.0mm_W9.0mm_P23.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L27.0mm_W9.0mm_P23.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L28.0mm_W10.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L28.0mm_W10.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 25.6 -5.35) (end -3.1 -5.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L28.0mm_W10.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L28.0mm_W10.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L28.0mm_W12.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L28.0mm_W12.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 25.6 -6.35) (end -3.1 -6.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L28.0mm_W12.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L28.0mm_W12.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L28.0mm_W8.0mm_P22.50mm_MKS4.kicad_mod
+++ b/C_Rect_L28.0mm_W8.0mm_P22.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 25.6 -4.35) (end -3.1 -4.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 22.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L28.0mm_W8.0mm_P22.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L28.0mm_W8.0mm_P22.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W11.0mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W11.0mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -5.85) (end -1.45 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W11.0mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W11.0mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W11.9mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W11.9mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -6.3) (end -1.45 -6.3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W11.9mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W11.9mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W12.2mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W12.2mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -6.45) (end -1.45 -6.45) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W12.2mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W12.2mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W13.0mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W13.0mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -6.85) (end -1.45 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W13.0mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W13.0mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W13.8mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W13.8mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -7.25) (end -1.45 -7.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W13.8mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W13.8mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W14.2mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W14.2mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -7.45) (end -1.45 -7.45) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W14.2mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W14.2mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W16.0mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W16.0mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -8.35) (end -1.45 -8.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W16.0mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W16.0mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W7.6mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W7.6mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -4.15) (end -1.45 -4.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W7.6mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W7.6mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W7.8mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W7.8mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -4.25) (end -1.45 -4.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W7.8mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W7.8mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W7.9mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W7.9mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -4.3) (end -1.45 -4.3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W7.9mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W7.9mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W9.1mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W9.1mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -4.9) (end -1.45 -4.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W9.1mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W9.1mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L29.0mm_W9.6mm_P27.50mm_MKT.kicad_mod
+++ b/C_Rect_L29.0mm_W9.6mm_P27.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 28.95 -5.15) (end -1.45 -5.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L29.0mm_W9.6mm_P27.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L29.0mm_W9.6mm_P27.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W11.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W11.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -5.85) (end -2.35 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W11.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W11.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W13.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W13.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -6.85) (end -2.35 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W13.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W13.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W15.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W15.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -7.85) (end -2.35 -7.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W15.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W15.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W17.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W17.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -8.85) (end -2.35 -8.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W17.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W17.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W20.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W20.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -10.35) (end -2.35 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W20.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W20.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L31.5mm_W9.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L31.5mm_W9.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -4.85) (end -2.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L31.5mm_W9.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L31.5mm_W9.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L32.0mm_W15.0mm_P27.00mm.kicad_mod
+++ b/C_Rect_L32.0mm_W15.0mm_P27.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 29.85 -7.85) (end -2.85 -7.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27 0) (size 2.2 2.2) (drill 1.1) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L32.0mm_W15.0mm_P27.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L32.0mm_W15.0mm_P27.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L33.0mm_W13.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L33.0mm_W13.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 30.6 -6.85) (end -3.1 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L33.0mm_W13.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L33.0mm_W13.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L33.0mm_W15.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L33.0mm_W15.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 30.6 -7.85) (end -3.1 -7.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L33.0mm_W15.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L33.0mm_W15.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L33.0mm_W20.0mm_P27.50mm_MKS4.kicad_mod
+++ b/C_Rect_L33.0mm_W20.0mm_P27.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 30.6 -10.35) (end -3.1 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 27.5 0) (size 2.4 2.4) (drill 1.2) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L33.0mm_W20.0mm_P27.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L33.0mm_W20.0mm_P27.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.0mm_W2.5mm_P2.50mm.kicad_mod
+++ b/C_Rect_L4.0mm_W2.5mm_P2.50mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 3.6 -1.6) (end -1.1 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.0mm_W2.5mm_P2.50mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.0mm_W2.5mm_P2.50mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.6mm_W2.0mm_P2.50mm_MKS02_FKP02.kicad_mod
+++ b/C_Rect_L4.6mm_W2.0mm_P2.50mm_MKS02_FKP02.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.9 -1.35) (end -1.4 -1.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.6mm_W2.0mm_P2.50mm_MKS02_FKP02.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.6mm_W2.0mm_P2.50mm_MKS02_FKP02.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.6mm_W3.0mm_P2.50mm_MKS02_FKP02.kicad_mod
+++ b/C_Rect_L4.6mm_W3.0mm_P2.50mm_MKS02_FKP02.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.9 -1.85) (end -1.4 -1.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.6mm_W3.0mm_P2.50mm_MKS02_FKP02.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.6mm_W3.0mm_P2.50mm_MKS02_FKP02.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.6mm_W3.8mm_P2.50mm_MKS02_FKP02.kicad_mod
+++ b/C_Rect_L4.6mm_W3.8mm_P2.50mm_MKS02_FKP02.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.9 -2.25) (end -1.4 -2.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.6mm_W3.8mm_P2.50mm_MKS02_FKP02.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.6mm_W3.8mm_P2.50mm_MKS02_FKP02.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.6mm_W4.6mm_P2.50mm_MKS02_FKP02.kicad_mod
+++ b/C_Rect_L4.6mm_W4.6mm_P2.50mm_MKS02_FKP02.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.9 -2.65) (end -1.4 -2.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.6mm_W4.6mm_P2.50mm_MKS02_FKP02.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.6mm_W4.6mm_P2.50mm_MKS02_FKP02.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L4.6mm_W5.5mm_P2.50mm_MKS02_FKP02.kicad_mod
+++ b/C_Rect_L4.6mm_W5.5mm_P2.50mm_MKS02_FKP02.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 3.9 -3.1) (end -1.4 -3.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 2.5 0) (size 1.4 1.4) (drill 0.7) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L4.6mm_W5.5mm_P2.50mm_MKS02_FKP02.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L4.6mm_W5.5mm_P2.50mm_MKS02_FKP02.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W11.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W11.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -5.85) (end -2.35 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W11.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W11.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W13.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W13.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -6.85) (end -2.35 -6.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W13.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W13.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W15.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W15.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -7.85) (end -2.35 -7.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W15.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W15.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W17.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W17.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -8.85) (end -2.35 -8.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W17.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W17.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W19.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W19.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -9.85) (end -2.35 -9.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W19.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W19.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W20.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W20.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -10.35) (end -2.35 -10.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W20.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W20.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W24.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W24.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -12.35) (end -2.35 -12.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W24.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W24.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W31.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W31.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -15.85) (end -2.35 -15.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W31.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W31.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W35.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W35.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -17.85) (end -2.35 -17.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W35.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W35.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W40.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W40.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -20.35) (end -2.35 -20.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W40.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W40.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L41.5mm_W9.0mm_P37.50mm_MKS4.kicad_mod
+++ b/C_Rect_L41.5mm_W9.0mm_P37.50mm_MKS4.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 39.85 -4.85) (end -2.35 -4.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 37.5 0) (size 2.8 2.8) (drill 1.4) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L41.5mm_W9.0mm_P37.50mm_MKS4.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L41.5mm_W9.0mm_P37.50mm_MKS4.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W2.0mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W2.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -1.35) (end -1.35 -1.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W2.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W2.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W2.5mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W2.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -1.6) (end -1.35 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W2.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W2.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W3.5mm_P2.50mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W3.5mm_P2.50mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (pad 2 thru_hole circle (at 3.75 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W3.5mm_P2.50mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W3.5mm_P2.50mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W3.5mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W3.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -2.1) (end -1.35 -2.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W3.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W3.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W4.5mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W4.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -2.6) (end -1.35 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W4.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W4.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W6.0mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W6.0mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.35 -3.35) (end -1.35 -3.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W6.0mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W6.0mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.0mm_W6.5mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.0mm_W6.5mm_P5.00mm.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 6.35 -3.6) (end -1.35 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.9) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.8 1.8) (drill 0.9) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.0mm_W6.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.0mm_W6.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W11.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W11.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -5.85) (end -1.45 -5.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W11.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W11.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W2.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W2.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -1.6) (end -1.45 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W2.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W2.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W3.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W3.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -1.85) (end -1.45 -1.85) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W3.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W3.0mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W3.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W3.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -2.1) (end -1.45 -2.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W3.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W3.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W4.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W4.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -2.6) (end -1.45 -2.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W4.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W4.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W5.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W5.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -3.1) (end -1.45 -3.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W5.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W5.5mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W7.2mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W7.2mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -3.95) (end -1.45 -3.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W7.2mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W7.2mm_P5.00mm_FKS2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.2mm_W8.5mm_P5.00mm_FKP2_FKP2_MKS2_MKP2.kicad_mod
+++ b/C_Rect_L7.2mm_W8.5mm_P5.00mm_FKP2_FKP2_MKS2_MKP2.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.45 -4.6) (end -1.45 -4.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.2mm_W8.5mm_P5.00mm_FKP2_FKP2_MKS2_MKP2.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.2mm_W8.5mm_P5.00mm_FKP2_FKP2_MKS2_MKP2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L7.5mm_W6.5mm_P5.00mm.kicad_mod
+++ b/C_Rect_L7.5mm_W6.5mm_P5.00mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 6.6 -3.6) (end -1.6 -3.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L7.5mm_W6.5mm_P5.00mm.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L7.5mm_W6.5mm_P5.00mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W2.5mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W2.5mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -1.6) (end -1.1 -1.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W2.5mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W2.5mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W2.6mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W2.6mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -1.65) (end -1.1 -1.65) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W2.6mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W2.6mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W2.7mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W2.7mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -1.7) (end -1.1 -1.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W2.7mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W2.7mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.2mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.2mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -1.95) (end -1.1 -1.95) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.2mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.2mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.3mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.3mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2) (end -1.1 -2) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.3mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.3mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.4mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.4mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.05) (end -1.1 -2.05) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.4mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.4mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.6mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.6mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.15) (end -1.1 -2.15) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.6mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.6mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.8mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.8mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.25) (end -1.1 -2.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.8mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.8mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W3.9mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W3.9mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.3) (end -1.1 -2.3) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W3.9mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W3.9mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W4.0mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W4.0mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.35) (end -1.1 -2.35) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W4.0mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W4.0mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W4.2mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W4.2mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.45) (end -1.1 -2.45) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W4.2mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W4.2mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W4.9mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W4.9mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.8) (end -1.1 -2.8) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W4.9mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W4.9mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W5.1mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W5.1mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -2.9) (end -1.1 -2.9) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W5.1mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W5.1mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W5.7mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W5.7mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -3.2) (end -1.1 -3.2) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W5.7mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W5.7mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W6.4mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W6.4mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -3.55) (end -1.1 -3.55) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W6.4mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W6.4mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W6.7mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W6.7mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -3.7) (end -1.1 -3.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W6.7mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W6.7mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W7.7mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W7.7mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -4.2) (end -1.1 -4.2) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W7.7mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W7.7mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W8.5mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W8.5mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -4.6) (end -1.1 -4.6) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W8.5mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W8.5mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W9.5mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W9.5mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -5.1) (end -1.1 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W9.5mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W9.5mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))

--- a/C_Rect_L9.0mm_W9.8mm_P7.50mm_MKT.kicad_mod
+++ b/C_Rect_L9.0mm_W9.8mm_P7.50mm_MKT.kicad_mod
@@ -23,7 +23,7 @@
   (fp_line (start 8.6 -5.25) (end -1.1 -5.25) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 0) (size 1.6 1.6) (drill 0.8) (layers *.Cu *.Mask))
-  (model Capacitors_ThroughHole.3dshapes/C_Rect_L9.0mm_W9.8mm_P7.50mm_MKT.wrl
+  (model Capacitors_THT.3dshapes/C_Rect_L9.0mm_W9.8mm_P7.50mm_MKT.wrl
     (at (xyz 0 0 0))
     (scale (xyz 0.393701 0.393701 0.393701))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Fixes references to 3D models from `Capacitors_ThroughHole` to `Capacitors_THT`